### PR TITLE
Generate tourney seeds from phrases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # adds .to_b for bools
 gem 'wannabe_bool'
 
+# QR code
+gem "rqrcode", "~> 2.0"
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
+    chunky_png (1.4.0)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -122,6 +123,10 @@ GEM
     redis (4.8.0)
     regexp_parser (2.6.2)
     rexml (3.2.5)
+    rqrcode (2.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rubocop (1.44.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -201,6 +206,7 @@ DEPENDENCIES
   pry-stack_explorer
   puma (>= 4.3.12)
   railties (= 6.1.7.1)
+  rqrcode (~> 2.0)
   rubocop
   rubocop-rails
   sass-rails (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,29 @@ the `brackets/results` directory. Note that the more exported files you use then
 results will tend towards highly ranked teams dominating and fewer upsets. Using a smaller set of exports
 will generate a high chance of upsets.
 
+## New Features in v1.1.0
+
+### Tourney Codes
+Every possible combination of brackets is encoded in a 13-character "tourney code." Entering a tourney
+code outputs the bracket wins/losses represented by that code. Each code is unique to exactly one
+bracket.
+
+### QR Codes
+Each bracket now comes with a QR code that can be used to share the bracket with others or open
+it on a mobile device. This QR code redirects to the tourney code page at `/code/:code`. Each QR code
+is unique to exactly one bracket.
+
+### Bracket Generator from Phrase
+
+Totally useless yet awesome at the same time! Enter any phrase and a bracket will be generated based
+on the content. Each phrase is deterministic (you get the same bracket if you enter the same phrase).
+Mess around and find phrases that result in good brackets! You can find this feature at `/phrase`.
+
 ## Future Work
 
-This is a quickly hacked together project for the 2021 NCAA Basketball Tournament. It will be expanded upon
-in the years to come. There are still a number of unimplemented features.
+This is a quickly hacked together project for the 2021 NCAA Basketball Tournament. It was polished a
+bit for the 2022 tournament, and the tourney codes were added for the 2023 tournament. It will be
+expanded upon in the years to come. There are still a number of unimplemented features.
 
 ### Testing
 
@@ -56,9 +75,3 @@ There are no tests yet. I know, I'm a bad developer. No cookie for me.
 Since the simulations heavily favor highly ranked teams, it would be nice to have a "Underdog Factor"
 scalar that can be used to slant games more towards the underdogs, thereby introducing a greater chance
 for upsets in the brackets.
-
-### Seeded Results
-
-I would like to have a hashed seed string that can be used to restore results to populate the brackets.
-Since there are 2^68 total possible brackets (that's _295 quintillion!_) it'd be great to be able to
-reproduce specific seeds. For now, the exported results files will have to do.

--- a/app/assets/stylesheets/tournament.scss
+++ b/app/assets/stylesheets/tournament.scss
@@ -334,3 +334,64 @@
     }
   }
 }
+
+.phrase_overlay {
+  position: absolute;
+  background-color: rgba(0,0,0,0.8);
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 99;
+
+  form {
+    position: absolute;
+    width: 600px;
+    top: 200px;
+    left: 800px;
+    margin-left: -315px;
+    background-color: white;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 5px 5px 3px rgba(0,0,0,0.5);
+    text-align: center;
+
+    label {
+      display: block;
+      font-weight: 700;
+      color: #333;
+      font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+      font-size: 20px;
+      margin-bottom: 10px;
+    }
+
+    textarea {
+      display: block;
+      width: 100%;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 14px;
+      padding: 5px;
+    }
+
+    input[type=submit] {
+      display: block;
+      width: 260px;
+      height: 40px;
+      color: #fff;
+      background-color: #009;
+      border: 1px solid #003;
+      margin-left: 170px;
+      margin-top: 10px;
+      border-radius: 4px;
+      font-size: 16px;
+      font-family: Arial, Helvetica, sans-serif;
+      font-weight: 700;
+
+      &:hover {
+        cursor: pointer;
+        background-color: #00c;
+        border: 1px solid #009;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/tournament.scss
+++ b/app/assets/stylesheets/tournament.scss
@@ -20,23 +20,60 @@
     text-align: center;
   }
 
+  .shims {
+    .shim {
+      position: absolute;
+
+      &.date_cover {
+        top: 102px;
+        left: 100px;
+        width: 1400px;
+        height: 20px;
+        background-color: white;
+      }
+
+      &.ff_date_cover {
+        top: 168px;
+        width: 80px;
+        height: 20px;
+        left: 758px;
+        background-color: #ddd;
+      }
+
+      &.championship_date_cover {
+        top: 630px;
+        width: 80px;
+        height: 20px;
+        left: 758px;
+        background-color: white;
+      }
+    }
+  }
+
   .team {
     position: relative;
     height: 18px;
     white-space: nowrap;
   }
 
-  .code {
+  .tourney_code {
     position: absolute;
-    user-select: all;
-    font-weight: 700;
-    font-size: 20px;
     width: 180px;
     top: 740px;
     left: 717px;
     text-align: center;
-    font-weight: bold;
-    word-wrap: nowrap;
+    
+    .code {
+      font-weight: bold;
+      word-wrap: nowrap;
+      user-select: all;
+      font-weight: 700;
+      font-size: 20px;
+    }
+
+    .qr_code {
+      margin-top: 10px;
+    }
   }
 
   .bracket_1, .bracket_2 {

--- a/app/controllers/tournament_controller.rb
+++ b/app/controllers/tournament_controller.rb
@@ -1,6 +1,6 @@
 class TournamentController < ApplicationController
   before_action :load_import_file, except: %i[qr_code]
-  before_action :identify_tourney_code!, except: %i[index]
+  before_action :identify_tourney_code!, only: %i[show qr_code]
 
   def index
     @tournament.play(params.permit(:export))
@@ -25,6 +25,16 @@ class TournamentController < ApplicationController
     )
 
     render inline: svg, format: :svg
+  end
+
+  def enter_phrase
+    render template: 'tournament/phrase'
+  end
+
+  def submit_phrase
+    phrase = params.require(:phrase)
+    @tourney_code = Tournament.create_tourney_code_from_phrase(phrase)
+    redirect_to "/code/#{@tourney_code}"
   end
 
   private

--- a/app/helpers/tournament_helper.rb
+++ b/app/helpers/tournament_helper.rb
@@ -10,6 +10,11 @@ module TournamentHelper
     "<div class='bracket bracket_#{bracket_num}'>\n#{render_teams(teams)}\n</div>".html_safe
   end
 
+  def render_empty_bracket(bracket_num, num_teams)
+    empty_teams = num_teams.times.map { |_| '???' }
+    render_bracket(bracket_num, empty_teams)
+  end
+
   def render_teams(teams)
     Array.wrap(teams).each_with_index.map do |team, idx|
       "<div class='team pos_#{idx}'>#{team}</div>"

--- a/app/helpers/tournament_helper.rb
+++ b/app/helpers/tournament_helper.rb
@@ -1,4 +1,11 @@
+require "rqrcode"
+
 module TournamentHelper
+  def render_qr_code(tourney_code)
+    tourney_code = ActionController::Base.helpers.sanitize(tourney_code)
+    "<img src='#{request.base_url}/qr/#{tourney_code}.svg' class='qr_svg qr_#{tourney_code}'>".html_safe
+  end
+
   def render_bracket(bracket_num, teams)
     "<div class='bracket bracket_#{bracket_num}'>\n#{render_teams(teams)}\n</div>".html_safe
   end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -85,6 +85,37 @@ class Tournament
       File.write("#{RESULTS_TOURNAMENT_PATH}/#{num}_#{version}.json", final_winners.to_json)
       final_winners
     end
+
+    # Converts tournament code to binary code
+    #
+    # @param tourney_code [String] tournament code
+    # @return [String] binary code
+    def convert_tourney_code_to_binary_code(tourney_code)
+      binary_code = tourney_code.gsub('-', '').to_i(36).to_s(2)
+      binary_code.prepend('0') while binary_code.size < TOTAL_GAMES
+      binary_code
+    end
+
+    # Converts tournament code to binary code
+    #
+    # @param binary_code [String] binary code representing Tournament results
+    # @return [String] binary code
+    def convert_binary_code_to_tourney_code(binary_code)
+      tourney_code = binary_code.to_i(2).to_s(36)
+      tourney_code.insert(1, '-') while tourney_code.length < CODE_LENGTH
+      tourney_code
+    end
+
+    # Enter a phrase and generate a tournament bracket! Fun for everyone!
+    #
+    # @param phrase [String] phraises like "march madness" and "boo-yah",
+    #   whatever you want creates a unique tournament
+    def create_tourney_code_from_phrase(phrase)
+      # Create hex hash based on string
+      hash = OpenSSL::Digest::SHA256.hexdigest(phrase)
+      binary_code = hash.to_i(16).to_s(2)[0...63]
+      convert_binary_code_to_tourney_code(binary_code)
+    end
   end
 
   # Creates a new tournament simulation
@@ -204,9 +235,7 @@ class Tournament
   #
   # @return [String] tournament code
   def to_tourney_code
-    tourney_code = to_binary_code.to_i(2).to_s(36)
-    tourney_code.insert(1, '-') while tourney_code.length < CODE_LENGTH
-    tourney_code
+    self.class.convert_binary_code_to_tourney_code(to_binary_code)
   end
 
   # Transforms the results to a binary code string, where '0' represents a home team
@@ -220,16 +249,6 @@ class Tournament
     end
   end
 
-  # Converts tournament code to binary code
-  #
-  # @param tourney_code [String] tournament code
-  # @return [String] binary code
-  def convert_tourney_code_to_binary_code(tourney_code)
-    binary_code = tourney_code.gsub('-', '').to_i(36).to_s(2)
-    binary_code.prepend('0') while binary_code.size < total_games
-    binary_code
-  end
-
   # Loads a Tournament bracket from a tournament cody
   #
   # @param tourney_code [String] tournament code
@@ -240,7 +259,7 @@ class Tournament
     reset
 
     @code = tourney_code
-    binary_code = convert_tourney_code_to_binary_code(tourney_code)
+    binary_code = self.class.convert_tourney_code_to_binary_code(tourney_code)
     load_from_binary_code(binary_code)
   end
 

--- a/app/views/tournament/index.html.erb
+++ b/app/views/tournament/index.html.erb
@@ -1,6 +1,12 @@
 <div class="brackets">
   <div class="title">2022 NCAA DIVISION I MEN'S BACKETBALL CHAMPIONSHIP</div>
 
+  <div class="shims">
+    <div class="shim date_cover"></div>
+    <div class="shim ff_date_cover"></div>
+    <div class="shim championship_date_cover"></div>
+  </div>
+
   <div class="first_four">
     <%= render_bracket(1, @tournament.first_four[0..1]) %>
     <%= render_bracket(2, @tournament.first_four[2..3]) %>
@@ -52,7 +58,8 @@
     <%= render_bracket(1, @tournament.winner) %>
   </div>
 
-  <div class="code">
-    <%= @tournament.code %>
+  <div class="tourney_code">
+    <div class="code"><%= @tournament.code %></div>
+    <div class="qr_code"><%= render_qr_code(@tournament.code) %></div>
   </div>
 </div>

--- a/app/views/tournament/phrase.html.erb
+++ b/app/views/tournament/phrase.html.erb
@@ -1,0 +1,73 @@
+<div class="brackets">
+  <div class="title">2022 NCAA DIVISION I MEN'S BACKETBALL CHAMPIONSHIP</div>
+
+  <div class="shims">
+    <div class="shim date_cover"></div>
+    <div class="shim ff_date_cover"></div>
+    <div class="shim championship_date_cover"></div>
+  </div>
+
+  <div class="first_four">
+    <%= render_bracket(1, @tournament.first_four[0..1]) %>
+    <%= render_bracket(2, @tournament.first_four[2..3]) %>
+    <%= render_bracket(3, @tournament.first_four[4..5]) %>
+    <%= render_bracket(4, @tournament.first_four[6..7]) %>
+  </div>
+
+  <div class="first_round">
+    <%= render_bracket(1, @tournament.teams[0..15]) %>
+    <%= render_bracket(2, @tournament.teams[16..31]) %>
+    <%= render_bracket(3, @tournament.teams[32..47]) %>
+    <%= render_bracket(4, @tournament.teams[48..63]) %>
+  </div>
+
+  <div class="second_round">
+    <%= render_empty_bracket(1, 8) %>
+    <%= render_empty_bracket(2, 8) %>
+    <%= render_empty_bracket(3, 8) %>
+    <%= render_empty_bracket(4, 8) %>
+  </div>
+
+  <div class="sweet_sixteen">
+    <%= render_empty_bracket(1, 4) %>
+    <%= render_empty_bracket(2, 4) %>
+    <%= render_empty_bracket(3, 4) %>
+    <%= render_empty_bracket(4, 4) %>
+  </div>
+
+  <div class="elite_eight">
+    <%= render_empty_bracket(1, 2) %>
+    <%= render_empty_bracket(2, 2) %>
+    <%= render_empty_bracket(3, 2) %>
+    <%= render_empty_bracket(4, 2) %>
+  </div>
+
+  <div class="final_four">
+    <%= render_empty_bracket(1, 1) %>
+    <%= render_empty_bracket(2, 1) %>
+    <%= render_empty_bracket(3, 1) %>
+    <%= render_empty_bracket(4, 1) %>
+  </div>
+
+  <div class="championship">
+    <%= render_empty_bracket(1, 1) %>
+    <%= render_empty_bracket(2, 1) %>
+  </div>
+
+  <div class="champion">
+    <%= render_empty_bracket(1, 1) %>
+  </div>
+
+  <div class="tourney_code">
+    <div class="code"></div>
+    <div class="qr_code"></div>
+  </div>
+</div>
+
+<div class="phrase_overlay">
+  <form method="get" action="/submit_phrase">
+    <label for="phrase">Enter any phrase you want to generate a custom bracket!</label>
+    <textarea id="phrase" name="phrase" rows="3"></textarea>
+    <input type="submit" value="Generate my bracket!">
+  </form>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root to: "tournament#index"
 
   get '/:code', to: "tournament#show"
+  get '/qr/:code', to: "tournament#qr_code"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: "tournament#index"
 
-  get '/:code', to: "tournament#show"
+  get '/code/:code', to: "tournament#show"
   get '/qr/:code', to: "tournament#qr_code"
+
+  get '/phrase', to: "tournament#enter_phrase"
+  get '/submit_phrase', to: "tournament#submit_phrase"
 end


### PR DESCRIPTION
* Adds QR code to brackets based on tourney code -- scanning this code will open the bracket via the `/code/:code` endpoint.
* Adds phrase-based bracket generation -- enter any phrase and a bracket will be spit out deterministically
* Updates README