### PR TITLE
Add 2023 tournament teams

### DIFF
--- a/app/assets/stylesheets/tournament.scss
+++ b/app/assets/stylesheets/tournament.scss
@@ -416,3 +416,94 @@
     }
   }
 }
+
+.avatar {
+  padding: 0px;
+  margin: 0px;
+
+  .avatar_tokens {
+    position: relative;
+    display: block;
+    padding: 0;
+    margin: 0;
+
+    .avatar_token {
+      position: relative;
+      display: block;
+      float: left;
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  .first_round {
+    .avatar_tokens {
+      height: 4px;
+      
+      .avatar_token {
+        width: 4px;
+        height: 4px;
+      }
+    }
+  }
+
+  .second_round {
+    .avatar_tokens {
+      height: 8px;
+      .avatar_token {
+        width: 8px;
+        height: 8px;
+      }
+    }
+  }
+
+  .sweet_sixteen {
+    .avatar_tokens {
+      height: 16px;
+      .avatar_token {
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+
+  .elite_eight {
+    .avatar_tokens {
+      height: 32px;
+      .avatar_token {
+        width: 32px;
+        height: 32px;
+      }
+    }
+  }
+
+  .final_four {
+    .avatar_tokens {
+      height: 64px;
+      .avatar_token {
+        width: 64px;
+        height: 64px;
+      }
+    }
+  }
+
+  .championship {
+    .avatar_tokens {
+      height: 128px;
+      .avatar_token {
+        width: 128px;
+        height: 128px;
+      }
+    }
+  }
+
+  .champion {
+    .avatar_tokens {
+      height: 256px;
+      .avatar_token {
+        width: 256px;
+        height: 256px;
+      }
+    }
+  }
+}

--- a/app/controllers/tournament_controller.rb
+++ b/app/controllers/tournament_controller.rb
@@ -1,6 +1,6 @@
 class TournamentController < ApplicationController
   before_action :load_import_file, except: %i[qr_code]
-  before_action :identify_tourney_code!, only: %i[show qr_code]
+  before_action :identify_tourney_code!, only: %i[show qr_code avatar]
 
   def index
     @tournament.play(params.permit(:export))
@@ -35,6 +35,11 @@ class TournamentController < ApplicationController
     phrase = params.require(:phrase)
     @tourney_code = Tournament.create_tourney_code_from_phrase(phrase)
     redirect_to "/c/#{@tourney_code}"
+  end
+
+  def avatar
+    @tournament.load_from_tourney_code(@tourney_code)
+    render template: 'tournament/avatar'
   end
 
   private

--- a/app/helpers/tournament_helper.rb
+++ b/app/helpers/tournament_helper.rb
@@ -20,4 +20,12 @@ module TournamentHelper
       "<div class='team pos_#{idx}'>#{team}</div>"
     end.join("\n")
   end
+
+  def render_avatar_tokens(bracket_num, teams)
+    team_tags = Array.wrap(teams).each_with_index.map do |team, idx|
+      "<div class='avatar_token avatar_token_#{idx}' style='background-color: #{team.color}'></div>"
+    end.join("\n")
+
+    "<div class='avatar_tokens bracket_#{bracket_num}'>\n#{team_tags}</div>".html_safe
+  end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,14 +1,16 @@
 # NCAA Basketball Tournament team
 class Team
-  attr_reader :name, :rank
+  attr_reader :name, :rank, :color
 
   # Creates a new team
   #
   # @param name [String] team name
   # @param rank [Integer] team rank
-  def initialize(name, rank)
+  # @param color [String] team color (plain text or hex)
+  def initialize(name, rank, color = nil)
     @name = name
     @rank = rank
+    @color = color || "##{SecureRandom.hex(3)}"
   end
 
   # @return [String] formatted rank and name of team

--- a/app/views/tournament/avatar.html.erb
+++ b/app/views/tournament/avatar.html.erb
@@ -1,0 +1,45 @@
+<div class="avatar">
+  <div class="first_round">
+    <%= render_avatar_tokens(1, @tournament.teams[0..15]) %>
+    <%= render_avatar_tokens(2, @tournament.teams[16..31]) %>
+    <%= render_avatar_tokens(3, @tournament.teams[32..47]) %>
+    <%= render_avatar_tokens(4, @tournament.teams[48..63]) %>
+  </div>
+
+  <div class="second_round">
+    <%= render_avatar_tokens(1, @tournament.rounds[0].winners[0..7]) %>
+    <%= render_avatar_tokens(2, @tournament.rounds[0].winners[8..15]) %>
+    <%= render_avatar_tokens(3, @tournament.rounds[0].winners[16..23]) %>
+    <%= render_avatar_tokens(4, @tournament.rounds[0].winners[24..31]) %>
+  </div>
+
+  <div class="sweet_sixteen">
+    <%= render_avatar_tokens(1, @tournament.rounds[1].winners[0..3]) %>
+    <%= render_avatar_tokens(2, @tournament.rounds[1].winners[4..7]) %>
+    <%= render_avatar_tokens(3, @tournament.rounds[1].winners[8..11]) %>
+    <%= render_avatar_tokens(4, @tournament.rounds[1].winners[12..15]) %>
+  </div>
+
+  <div class="elite_eight">
+    <%= render_avatar_tokens(1, @tournament.rounds[2].winners[0..1]) %>
+    <%= render_avatar_tokens(2, @tournament.rounds[2].winners[2..3]) %>
+    <%= render_avatar_tokens(3, @tournament.rounds[2].winners[4..5]) %>
+    <%= render_avatar_tokens(4, @tournament.rounds[2].winners[6..7]) %>
+  </div>
+
+  <div class="final_four">
+    <%= render_avatar_tokens(1, @tournament.rounds[3].winners[0]) %>
+    <%= render_avatar_tokens(2, @tournament.rounds[3].winners[1]) %>
+    <%= render_avatar_tokens(3, @tournament.rounds[3].winners[2]) %>
+    <%= render_avatar_tokens(4, @tournament.rounds[3].winners[3]) %>
+  </div>
+
+  <div class="championship">
+    <%= render_avatar_tokens(1, @tournament.rounds[4].winners[0]) %>
+    <%= render_avatar_tokens(2, @tournament.rounds[4].winners[1]) %>
+  </div>
+
+  <div class="champion">
+    <%= render_avatar_tokens(1, @tournament.winner) %>
+  </div>
+</div>

--- a/app/views/tournament/index.html.erb
+++ b/app/views/tournament/index.html.erb
@@ -1,5 +1,5 @@
 <div class="brackets">
-  <div class="title">2022 NCAA DIVISION I MEN'S BACKETBALL CHAMPIONSHIP</div>
+  <div class="title"><%= @tournament.year %> NCAA DIVISION I MEN'S BACKETBALL CHAMPIONSHIP</div>
 
   <div class="shims">
     <div class="shim date_cover"></div>

--- a/brackets/2022_results.json
+++ b/brackets/2022_results.json
@@ -1,0 +1,266 @@
+{
+    "First Round Winners": [
+        {
+            "name": "Gonzaga",
+            "rank": 1
+        },
+        {
+            "name": "Memphis",
+            "rank": 9
+        },
+        {
+            "name": "New Mexico State",
+            "rank": 12
+        },
+        {
+            "name": "Arkansas",
+            "rank": 4
+        },
+        {
+            "name": "Notre Dame",
+            "rank": 11
+        },
+        {
+            "name": "Texas Tech",
+            "rank": 3
+        },
+        {
+            "name": "Michigan St",
+            "rank": 7
+        },
+        {
+            "name": "Duke",
+            "rank": 2
+        },
+        {
+            "name": "Baylor",
+            "rank": 1
+        },
+        {
+            "name": "Marquette",
+            "rank": 9
+        },
+        {
+            "name": "Saint Mary's",
+            "rank": 5
+        },
+        {
+            "name": "UCLA",
+            "rank": 4
+        },
+        {
+            "name": "Texas",
+            "rank": 6
+        },
+        {
+            "name": "Purdue",
+            "rank": 3
+        },
+        {
+            "name": "Murray State",
+            "rank": 7
+        },
+        {
+            "name": "St Peter's",
+            "rank": 15
+        },
+        {
+            "name": "Arizona",
+            "rank": 1
+        },
+        {
+            "name": "TCU",
+            "rank": 9
+        },
+        {
+            "name": "Houston",
+            "rank": 5
+        },
+        {
+            "name": "Illinois",
+            "rank": 4
+        },
+        {
+            "name": "Michigan",
+            "rank": 11
+        },
+        {
+            "name": "Tennessee",
+            "rank": 3
+        },
+        {
+            "name": "Ohio St",
+            "rank": 7
+        },
+        {
+            "name": "Villanova",
+            "rank": 2
+        },
+        {
+            "name": "Kansas",
+            "rank": 1
+        },
+        {
+            "name": "Creighton",
+            "rank": 9
+        },
+        {
+            "name": "Richmond",
+            "rank": 12
+        },
+        {
+            "name": "Providence",
+            "rank": 4
+        },
+        {
+            "name": "Iowa St",
+            "rank": 11
+        },
+        {
+            "name": "Wisconsin",
+            "rank": 3
+        },
+        {
+            "name": "Miami FL",
+            "rank": 10
+        },
+        {
+            "name": "Auburn",
+            "rank": 2
+        }
+    ],
+    "Second Round Winners": [
+        {
+            "name": "Gonzaga",
+            "rank": 1
+        },
+        {
+            "name": "Arkansas",
+            "rank": 4
+        },
+        {
+            "name": "Alabama",
+            "rank": 6
+        },
+        {
+            "name": "Duke",
+            "rank": 2
+        },
+        {
+            "name": "UNC",
+            "rank": 8
+        },
+        {
+            "name": "UCLA",
+            "rank": 13
+        },
+        {
+            "name": "Purdue",
+            "rank": 3
+        },
+        {
+            "name": "St Peter's",
+            "rank": 15
+        },
+        {
+            "name": "Arizona",
+            "rank": 1
+        },
+        {
+            "name": "Houston",
+            "rank": 5
+        },
+        {
+            "name": "Michigan",
+            "rank": 11
+        },
+        {
+            "name": "Villanova",
+            "rank": 2
+        },
+        {
+            "name": "Kansas",
+            "rank": 1
+        },
+        {
+            "name": "Providence",
+            "rank": 4
+        },
+        {
+            "name": "Iowa St",
+            "rank": 11
+        },
+        {
+            "name": "Miami FL",
+            "rank": 10
+        }
+    ],
+    "Sweet Sixteen Winners": [
+        {
+            "name": "Arkansas",
+            "rank": 4
+        },
+        {
+            "name": "Duke",
+            "rank": 2
+        },
+        {
+            "name": "UNC",
+            "rank": 8
+        },
+        {
+            "name": "St Peter's",
+            "rank": 15
+        },
+        {
+            "name": "Houston",
+            "rank": 5
+        },
+        {
+            "name": "Villanova",
+            "rank": 2
+        },
+        {
+            "name": "Kansas",
+            "rank": 1
+        },
+        {
+            "name": "Miami FL",
+            "rank": 10
+        }
+    ],
+    "Elite Eight Winners": [
+        {
+            "name": "Duke",
+            "rank": 2
+        },
+        {
+            "name": "UNC",
+            "rank": 8
+        },
+        {
+            "name": "Villanova",
+            "rank": 2
+        },
+        {
+            "name": "Kansas",
+            "rank": 1
+        }
+    ],
+    "Final Four Winners": [
+        {
+            "name": "UNC",
+            "rank": 8
+        },
+        {
+            "name": "Kansas",
+            "rank": 1
+        }
+    ],
+    "Championship Winners": [
+        {
+            "name": "Kansas",
+            "rank": 1
+        }
+    ]
+}

--- a/brackets/import/ncaa_2023.json
+++ b/brackets/import/ncaa_2023.json
@@ -2,47 +2,111 @@
     "teams": [
         {
             "rank": 1,
-            "name": "Gonzaga"
-        },
-        {
-            "rank": 16,
-            "name": "Georgia St"
-        },
-        {
-            "rank": 8,
-            "name": "Boise St"
-        },
-        {
-            "rank": 9,
-            "name": "Memphis"
-        },
-        {
-            "rank": 5,
-            "name": "Connecticut"
-        },
-        {
-            "rank": 12,
-            "name": "N Mexico St"
-        },
-        {
-            "rank": 4,
-            "name": "Arkansas"
-        },
-        {
-            "rank": 13,
-            "name": "Vermont"
-        },
-        {
-            "rank": 6,
             "name": "Alabama"
         },
         {
+            "rank": 16,
+            "name": "TXCC/SEMO"
+        },
+        {
+            "rank": 8,
+            "name": "Maryland"
+        },
+        {
+            "rank": 9,
+            "name": "West Virginia"
+        },
+        {
+            "rank": 5,
+            "name": "San Diego St"
+        },
+        {
+            "rank": 12,
+            "name": "Charleston"
+        },
+        {
+            "rank": 4,
+            "name": "Virginia"
+        },
+        {
+            "rank": 13,
+            "name": "Furman"
+        },
+        {
+            "rank": 6,
+            "name": "Creighton"
+        },
+        {
             "rank": 11,
-            "name": "RUTG/ND"
+            "name": "NC State"
         },
         {
             "rank": 3,
-            "name": "Texas Tech"
+            "name": "Baylor"
+        },
+        {
+            "rank": 14,
+            "name": "UCSB"
+        },
+        {
+            "rank": 7,
+            "name": "Missouri"
+        },
+        {
+            "rank": 10,
+            "name": "Utah State"
+        },
+        {
+            "rank": 2,
+            "name": "Arizona"
+        },
+        {
+            "rank": 15,
+            "name": "Princeton"
+        },
+        {
+            "rank": 1,
+            "name": "Purdue"
+        },
+        {
+            "rank": 16,
+            "name": "TXSO/FDU"
+        },
+        {
+            "rank": 8,
+            "name": "Memphis"
+        },
+        {
+            "rank": 9,
+            "name": "FAU"
+        },
+        {
+            "rank": 5,
+            "name": "Duke"
+        },
+        {
+            "rank": 12,
+            "name": "Oral Roberts"
+        },
+        {
+            "rank": 4,
+            "name": "Tennessee"
+        },
+        {
+            "rank": 13,
+            "name": "Louisiana"
+        },
+        {
+            "rank": 6,
+            "name": "Kentucky"
+        },
+        {
+            "rank": 11,
+            "name": "Providence"
+        },
+        {
+            "rank": 3,
+            "name": "Kansas St"
         },
         {
             "rank": 14,
@@ -54,143 +118,79 @@
         },
         {
             "rank": 10,
-            "name": "Davidson"
+            "name": "USC"
         },
         {
             "rank": 2,
-            "name": "Duke"
-        },
-        {
-            "rank": 15,
-            "name": "CS Fullerton"
-        },
-        {
-            "rank": 1,
-            "name": "Baylor"
-        },
-        {
-            "rank": 16,
-            "name": "Norfolk St"
-        },
-        {
-            "rank": 8,
-            "name": "North Carolina"
-        },
-        {
-            "rank": 9,
             "name": "Marquette"
         },
         {
-            "rank": 5,
-            "name": "Saint Mary's"
-        },
-        {
-            "rank": 12,
-            "name": "WYO/IND"
-        },
-        {
-            "rank": 4,
-            "name": "UCLA"
-        },
-        {
-            "rank": 13,
-            "name": "Akron"
-        },
-        {
-            "rank": 6,
-            "name": "Texas"
-        },
-        {
-            "rank": 11,
-            "name": "Virginia Tech"
-        },
-        {
-            "rank": 3,
-            "name": "Purdue"
-        },
-        {
-            "rank": 14,
-            "name": "Yale"
-        },
-        {
-            "rank": 7,
-            "name": "Murray St"
-        },
-        {
-            "rank": 10,
-            "name": "San Franscisco"
-        },
-        {
-            "rank": 2,
-            "name": "Kentucky"
-        },
-        {
             "rank": 15,
-            "name": "St Peter's"
+            "name": "Vermont"
         },
         {
             "rank": 1,
-            "name": "Arizona"
-        },
-        {
-            "rank": 16,
-            "name": "WRST/BRY"
-        },
-        {
-            "rank": 8,
-            "name": "Seton Hall"
-        },
-        {
-            "rank": 9,
-            "name": "TCU"
-        },
-        {
-            "rank": 5,
             "name": "Houston"
         },
         {
+            "rank": 16,
+            "name": "N Kentucky"
+        },
+        {
+            "rank": 8,
+            "name": "Iowa"
+        },
+        {
+            "rank": 9,
+            "name": "Auburn"
+        },
+        {
+            "rank": 5,
+            "name": "Miami"
+        },
+        {
             "rank": 12,
-            "name": "UAB"
+            "name": "Drake"
         },
         {
             "rank": 4,
-            "name": "Illinois"
+            "name": "Indiana"
         },
         {
             "rank": 13,
-            "name": "Chattanooga"
+            "name": "Kent St"
         },
         {
             "rank": 6,
-            "name": "Colorado St"
+            "name": "Iowa St"
         },
         {
             "rank": 11,
-            "name": "Michigan"
+            "name": "MSST/Pitt"
         },
         {
             "rank": 3,
-            "name": "Tennessee"
+            "name": "Xavier"
         },
         {
             "rank": 14,
-            "name": "Longwood"
+            "name": "Kennesaw St"
         },
         {
             "rank": 7,
-            "name": "Ohio St"
+            "name": "Texas A&M"
         },
         {
             "rank": 10,
-            "name": "Loyola Chicago"
+            "name": "Penn St"
         },
         {
             "rank": 2,
-            "name": "Villanova"
+            "name": "Texas"
         },
         {
             "rank": 15,
-            "name": "Delaware"
+            "name": "Colgate"
         },
         {
             "rank": 1,
@@ -198,63 +198,63 @@
         },
         {
             "rank": 16,
-            "name": "TXSO/TAMC"
+            "name": "Howard"
         },
         {
             "rank": 8,
-            "name": "San Diego St"
+            "name": "Arkansas"
         },
         {
             "rank": 9,
-            "name": "Creighton"
+            "name": "Illinois"
         },
         {
             "rank": 5,
-            "name": "Iowa"
+            "name": "St Mary's"
         },
         {
             "rank": 12,
-            "name": "Richmond"
+            "name": "VCU"
         },
         {
             "rank": 4,
-            "name": "Providence"
+            "name": "UConn"
         },
         {
             "rank": 13,
-            "name": "S Dakota St"
+            "name": "Iona"
         },
         {
             "rank": 6,
-            "name": "LSU"
+            "name": "TCU"
         },
         {
             "rank": 11,
-            "name": "Iowa St"
+            "name": "ASU/Nev"
         },
         {
             "rank": 3,
-            "name": "Wisconsin"
+            "name": "Gonzaga"
         },
         {
             "rank": 14,
-            "name": "Colgate"
+            "name": "Grand Canyon"
         },
         {
             "rank": 7,
-            "name": "USC"
+            "name": "Northwestern"
         },
         {
             "rank": 10,
-            "name": "Miami FL"
+            "name": "Boise St"
         },
         {
             "rank": 2,
-            "name": "Auburn"
+            "name": "UCLA"
         },
         {
             "rank": 15,
-            "name": "Jax State"
+            "name": "UNC Ash"
         }
     ]
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   get '/c/:code', to: "tournament#show"
   get '/qr/:code', to: "tournament#qr_code"
+  get '/avatar/:code', to: "tournament#avatar"
 
   get '/phrase', to: "tournament#enter_phrase"
   get '/submit_phrase', to: "tournament#submit_phrase"


### PR DESCRIPTION
* Adds 2023 tournament teams in `ncaa_2023.json`
* Adds projected points and probability
* Adds placeholder for team avatars (to be implemented in future PR)
